### PR TITLE
Add  [Parameter]  attribute to Article.cshtml.

### DIFF
--- a/src/BlazorRealworld/Pages/Article.cshtml
+++ b/src/BlazorRealworld/Pages/Article.cshtml
@@ -141,7 +141,8 @@
 
 @functions
 {
-    public string Slug { get; set; }
+    [Parameter]
+    string Slug { get; set; }
 
     ArticleModel article = null;
 


### PR DESCRIPTION
Added [Parameter] attribute on  `string Slug { get; set; }` and removed public access modifier. Which was preventing from open articles detail view.

![image](https://user-images.githubusercontent.com/9201481/40274722-2db334c4-5bfe-11e8-90b9-9290d735f4cc.png)
